### PR TITLE
Add new venues for Phnom Penh and Taipei

### DIFF
--- a/data/venues/kh-nagaworld-phnom-penh.yaml
+++ b/data/venues/kh-nagaworld-phnom-penh.yaml
@@ -1,0 +1,10 @@
+slug: "kh-nagaworld-phnom-penh"
+name: "NagaWorld"
+url: "https://www.nagaworld.com/"
+google_maps_url: "https://maps.google.com/?q=11.5556255,104.9372314"
+address: "Samdech Hun Sen Park, Phnom Penh, Cambodia"
+city: "Phnom Penh"
+state: ""
+country_code: "KH"
+latitude: 11.5556255
+longitude: 104.9372314

--- a/data/venues/tw-red-space-taipei.yaml
+++ b/data/venues/tw-red-space-taipei.yaml
@@ -1,0 +1,10 @@
+slug: "tw-red-space-taipei"
+name: "Red Space"
+url: "https://www.redpointcenter.com.tw/red-space/"
+google_maps_url: "https://maps.google.com/?q=25.0518,121.5440"
+address: "Fuxing N Rd, Songshan District, Taipei City 105, Taiwan"
+city: "Taipei"
+state: "Taipei City"
+country_code: "TW"
+latitude: 25.0518
+longitude: 121.5440


### PR DESCRIPTION
## Summary
- add Nagaworld venue in Phnom Penh, Cambodia
- add Red Space venue in Taipei, Taiwan

## Testing
- `yamale -s schema/venue.yaml data/venues/kh-nagaworld-phnom-penh.yaml`
- `yamale -s schema/venue.yaml data/venues/tw-red-space-taipei.yaml`
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_684e5246d65c833181c197cf751d1299